### PR TITLE
fixed rabbitmq_users tag bug

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -48,7 +48,7 @@
     user: "{{ item.user }}"
     password: "{{ item.user | default('') }}"
     vhost: "{{ item.vhost | default('/') }}"
-    tags: "{{ item.tags | join(',') | default('') }}"
+    tags: "{{ item.tags | default([]) | join(',') }}"
     configure_priv: "{{ item.configure_priv | default('^$') }}"
     read_priv: "{{ item.read_priv | default('^$') }}"
     write_priv: "{{ item.write_priv | default('^$') }}"


### PR DESCRIPTION
the `rabbitmq_users` variable contains a list of objects each having a `tag` field. This field was previously required, but according to the documentation, it wasn't. This commit brings the code more in line with the documentation.

The `default` macro was placed after the `join` macro. Since `join` doesn't work on nulls, this effectively caused the `tags` field to be required for each entry in the `rabbitmq_users` variable.
