### PR TITLE
rabbitmq_policy variable changes

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
     - name: EL
       versions:
         - 6
+        - 7
   categories:
     - monitoring
     - networking

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -62,7 +62,7 @@
     name: "{{ item.name }}"
     node: "{{ item.node | default('rabbit') }}"
     pattern: "{{ item.pattern | default('^$') }}"
-    priority: "{{ item.priority | default(1) }}"
+    priority: "{{ item.priority | default(0) }}"
     state: "{{ item.state | default('present') }}"
     tags: "{{ item.tags | default('') }}"
     vhost: "{{ item.vhost | default('/') }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -63,7 +63,7 @@
     node: "{{ item.node | default('rabbit') }}"
     pattern: "{{ item.pattern | default('^$') }}"
     priority: "{{ item.priority | default(1) }}"
-    state: "{{ item.tags | default('present') }}"
+    state: "{{ item.state | default('present') }}"
     tags: "{{ item.tags | default('') }}"
     vhost: "{{ item.vhost | default('/') }}"
   with_items: rabbitmq_policies

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -46,7 +46,7 @@
 - name: Manage RabbitMQ users
   rabbitmq_user:
     user: "{{ item.user }}"
-    password: "{{ item.user | default('') }}"
+    password: "{{ item.password | default('') }}"
     vhost: "{{ item.vhost | default('/') }}"
     tags: "{{ item.tags | default([]) | join(',') }}"
     configure_priv: "{{ item.configure_priv | default('^$') }}"


### PR DESCRIPTION
The `state` field of the `rabbitmq_policy` variable was fixed so that it ot relies on the corresponding field in a `rabbitmq_policies` entry.

The `pattern`, `priority`, and `tags` fields have been brought in line with the documentation. 
